### PR TITLE
Added (proper) python support

### DIFF
--- a/gl0buli.sh
+++ b/gl0buli.sh
@@ -18,7 +18,7 @@ showHelp() {
 	echo "USAGE:"
 	echo -e "\tgl0buli.sh language\n"
 	echo "Available languages:"
-	echo -e "\tphp applescript bash c c++ ruby java javascript perl"
+	echo -e "\tphp applescript bash c c++ ruby java javascript perl python"
 }
 
 
@@ -30,7 +30,7 @@ selectLanguage() {
 		applescript)
 			tag="doubleminus"
 		;;
-		bash|ruby|perl)
+		bash|ruby|perl|python)
 		tag="hash"
 		;;
 		-h|*)
@@ -62,6 +62,17 @@ getRandomness() {
 
 rot13() {
 	echo $1 | tr A-Za-z N-ZA-Mn-za-m
+}
+
+sieve () {
+	case $1 in
+		python)
+			echo $2 | tr "acefijmopqruvxzACEFIJMOPQRUVXZ13579" "	                   "
+		;;
+		*)
+			echo $2
+		;;
+	esac
 }
 
 
@@ -119,6 +130,7 @@ echo "Oooops, our gl0buli is too large. Let's the most important…"
 echo "Yeah, this ancient monk stuff"
 gl0buli=`echo $gl0buli | cut -c1-10`
 
+gl0buli=$(sieve $input $gl0buli)
 
 echo "CONGRATULATION! Now you have your own gl0buli!"
 echo ""


### PR DESCRIPTION
As everyone knows, whitespace is very important for programming in python. Therefore, if we sieve our gl0buli another time together with some whitespaces, we an end up with an even more powerful gl0buli!

This, of course, only works with the fondly hand-crafted selection of Unicode whitespace symbols included in this pull request.
